### PR TITLE
Extended categories and tag functionality

### DIFF
--- a/includes/compatibility/edd/functions-download-details.php
+++ b/includes/compatibility/edd/functions-download-details.php
@@ -92,13 +92,13 @@ function themedd_edd_has_download_details( $options = array() ) {
  *
  * @since 1.0.0
  */
-function themedd_edd_download_categories( $download_id = 0 ) {
+function themedd_edd_download_categories( $download_id = 0, $before = '', $sep = ', ', $after = '' ) {
 
 	if ( ! $download_id ) {
 		return false;
 	}
 
-	$categories = get_the_term_list( $download_id, 'download_category', '', ', ', '' );
+	$categories = get_the_term_list( $download_id, 'download_category', $before, $sep, $after );
 
 	if ( $categories ) {
 		return $categories;
@@ -113,13 +113,13 @@ function themedd_edd_download_categories( $download_id = 0 ) {
  *
  * @since 1.0.0
  */
-function themedd_edd_download_tags( $download_id = 0 ) {
+function themedd_edd_download_tags( $download_id = 0, $before = '', $sep = ', ', $after = '' ) {
 
 	if ( ! $download_id ) {
 		return false;
 	}
 
-	$tags = get_the_term_list( $download_id, 'download_tag', '', ', ', '' );
+	$tags = get_the_term_list( $download_id, 'download_tag', $before, $sep, $after );
 
 	if ( $tags ) {
 		return $tags;


### PR DESCRIPTION
Extended the `themedd_edd_download_categories` and `themedd_edd_download_tags` functions to allow the `before`, `separator` and `after` parameters, allowing for more control over the output (for example - removing the comma delimitation to use `divs` instead).