### PR TITLE
Add action hooks to themedd_colors_output_customizer_styling function

### DIFF
--- a/includes/customizer.php
+++ b/includes/customizer.php
@@ -1240,6 +1240,8 @@ if ( ! function_exists( 'themedd_colors_output_customizer_styling' ) ) :
 		if ( ! empty( $colors ) ) : ?>
 			<style id="themedd-custom-css" type="text/css">
 			<?php
+		
+			do_action( 'themedd_colors_output_customizer_styling_before', $colors );
 
 			// Tagline color.
 			if ( isset( $colors['tagline_color'] ) ) {
@@ -1451,6 +1453,8 @@ if ( ! function_exists( 'themedd_colors_output_customizer_styling' ) ) :
 			if ( isset( $colors['footer_site_info_color'] ) ) {
 				echo '.site-info { color:' . $colors['footer_site_info_color'] . '; }';
 			}
+		
+			do_action( 'themedd_colors_output_customizer_styling_after', $colors );
 
 			?>
 		</style>


### PR DESCRIPTION
For child theme developers, it would be useful to have action hooks `before` and `after` the main `themedd_colors_output_customizer_styling` section to allow additional elements to be styled during the routine.