### PR TITLE
Added default classes for footer widget column classes

### DIFF
--- a/includes/footer.php
+++ b/includes/footer.php
@@ -107,6 +107,8 @@ function themedd_footer_widget_column_classes( $widget_columns ) {
 		case 1:
 			$classes = 'col-xs-12 col-sm-6';
 			break;
+		default:
+       			$classes = '';
 
 	}
 


### PR DESCRIPTION
In case you increase the number of widget columns to e.g. 5, the current function/filter always throws a "PHP Notice:  Undefined variable: classes in /includes/footer.php on line 113" because $classes is not defined