### PR TITLE
Remove schema markup from cross-sell/upsell output

### DIFF
--- a/includes/compatibility/edd/class-cross-sell-upsell.php
+++ b/includes/compatibility/edd/class-cross-sell-upsell.php
@@ -61,9 +61,8 @@ class Themedd_EDD_Cross_Sell_Upsell {
 		<?php
 		$i = 1;
 		while ( $downloads->have_posts() ) : $downloads->the_post(); ?>
-			<?php $schema = edd_add_schema_microdata() ? 'itemscope itemtype="http://schema.org/Product" ' : ''; ?>
 
-			<div <?php echo $schema; ?>class="<?php echo apply_filters( 'edd_download_class', 'edd_download', get_the_ID(), '', $i ); ?>" id="edd_download_<?php echo get_the_ID(); ?>">
+			<div class="<?php echo apply_filters( 'edd_download_class', 'edd_download', get_the_ID(), '', $i ); ?>" id="edd_download_<?php echo get_the_ID(); ?>">
 				<div class="edd_download_inner">
 
 					<?php


### PR DESCRIPTION
Fixes #254

Since the extension disables the schema output before building the HTML markup, and (I believe) re-applies it too early/in error, I think the right thing here is to just remove it from the theme output altogether.